### PR TITLE
Audio fixes, tutorial and finale fixes

### DIFF
--- a/CULLinary/Assets/CULLinary/Art/Code/MainMenu.cs
+++ b/CULLinary/Assets/CULLinary/Art/Code/MainMenu.cs
@@ -16,6 +16,8 @@ public class MainMenu : MonoBehaviour
     [SerializeField] private GameObject optionsMenu;
     [SerializeField] private GameObject mainButtonsMenu;
     [SerializeField] private GameObject loadGameButton;
+
+    public AudioMixer audioMixer;
     
     private Animator animator;
 
@@ -46,12 +48,23 @@ public class MainMenu : MonoBehaviour
 
     void Update()
     {
+        float targetVolume = 0.0001f;
+        string channel = "Master_Vol";
         if (fading) {
             if (foreground.color.a <= 0.95f) {
+
+                float rawVolume;
+                audioMixer.GetFloat(channel, out rawVolume);
+                float currentVolume = Mathf.Pow(10, rawVolume / 20);
+                float newVolume = Mathf.Lerp(currentVolume, targetVolume, fadeSpeed * Time.deltaTime);
+                audioMixer.SetFloat("Master_Vol", Mathf.Log10(newVolume) * 20);
+
                 foreground.color = Color.Lerp(foreground.color, Color.black, fadeSpeed * Time.deltaTime);
             } else {
                 fading = false;
                 foreground.color = Color.black;
+                // Options Menu will handle setting Master_Vol
+                // back to 0 on new scene load
                 afterFade();
             }
         }

--- a/CULLinary/Assets/CULLinary/Audio/mixers/Main Mixer.mixer
+++ b/CULLinary/Assets/CULLinary/Audio/mixers/Main Mixer.mixer
@@ -51,6 +51,8 @@ AudioMixerController:
   m_ExposedParameters:
   - guid: d03b7469cd79fce3594cbf888e9be67d
     name: BG_Vol
+  - guid: 9aa67325cb05578af87bc9c11bcfd042
+    name: Master_Vol
   - guid: 58f2ff7917458618e8ca84dcd3118c82
     name: SFX_Vol
   m_AudioMixerGroupViews:

--- a/CULLinary/Assets/CULLinary/Code/AudioHelper.cs
+++ b/CULLinary/Assets/CULLinary/Code/AudioHelper.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.Audio;
+using UnityEngine;
+
+public static class AudioHelper {
+    // Credits:
+    // https://gamedevbeginner.com/how-to-fade-audio-in-unity-i-tested-every-method-this-ones-the-best/
+    public static IEnumerator FadeAudio(AudioMixer audioMixer, string channel, float duration)
+    {
+        Debug.Log("Fade!");
+        float rawVolume;
+        audioMixer.GetFloat(channel, out rawVolume);
+        float currentVolume = Mathf.Pow(10, rawVolume / 20);
+        float targetVolume = 0.0001f;
+
+        float currentTime = 0;
+        while (currentTime < duration)
+        {
+            currentTime = currentTime + Time.deltaTime;
+            float newVolume = Mathf.Lerp(currentVolume, targetVolume, currentTime / duration);
+            audioMixer.SetFloat(channel, Mathf.Log10(newVolume) * 20);
+            yield return null;
+        }
+        yield break;
+    }
+}

--- a/CULLinary/Assets/CULLinary/Code/AudioHelper.cs.meta
+++ b/CULLinary/Assets/CULLinary/Code/AudioHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd8f62e92daaca544a3bb2fefc080816
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary/Assets/CULLinary/Code/FinaleController.cs
+++ b/CULLinary/Assets/CULLinary/Code/FinaleController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Audio;
 using UnityEngine.SceneManagement;
 
 public class FinaleController : MonoBehaviour
@@ -12,6 +13,10 @@ public class FinaleController : MonoBehaviour
     public DialogueLoader dialogueLoader;
     public Restaurant_CustomerController customerController;   
     public CookingStation movementController; // CookingStation to disable movement when speaking to ClownerCust
+
+    public AudioMixer audio; // to fade sounds
+
+    private float creditsDuration = 27.0f;
 
     // Start is called before the first frame update
     void Start()
@@ -57,23 +62,26 @@ public class FinaleController : MonoBehaviour
         yield return new WaitForSeconds(1.5f);
 
         rollingCreditsAnimator.SetBool("LetsRoll", true); // Roll da credits
-        
-        yield return new WaitForSeconds(1.5f);
 
         StartCoroutine(GoBackMenu()); // initially GoBackRestaurant() but i think loading back to main menu makes more sense??
     }
 
     IEnumerator GoBackRestaurant()
     {
-        yield return new WaitForSeconds(27);
+        yield return new WaitForSeconds(creditsDuration);
 
         SceneManager.LoadScene((int)SceneIndexes.REST); // Load restaurant scene 
     }
 
     IEnumerator GoBackMenu()
     {
-        yield return new WaitForSeconds(27);
+        float fadeDuration = 1.5f;
+        yield return new WaitForSeconds(creditsDuration - fadeDuration);
 
-        SceneManager.LoadScene((int)SceneIndexes.MAINMENU); // Load restaurant scene 
+        StartCoroutine(AudioHelper.FadeAudio(audio, "Master_Vol", fadeDuration));
+        yield return new WaitForSeconds(fadeDuration);
+
+        PlayerPrefs.SetInt("Just_Won_Game", 1);             // Trigger victory music in main menu
+        SceneManager.LoadScene((int)SceneIndexes.MAINMENU); // Load main menu scene 
     }
 }

--- a/CULLinary/Assets/CULLinary/Code/FinaleController.cs
+++ b/CULLinary/Assets/CULLinary/Code/FinaleController.cs
@@ -8,6 +8,7 @@ public class FinaleController : MonoBehaviour
 {
     public Animator blackscreenAnimator;
     public Animator rollingCreditsAnimator;
+    public GameObject creditsCanvas;
 
     public GameObject clownerCust;
     public DialogueLoader dialogueLoader;
@@ -43,6 +44,7 @@ public class FinaleController : MonoBehaviour
                 dialogueLoader.LoadAndRun(clownerDialogue, customerController);
                 dialogueLoader.SetDialogueEndCallback(() => {
                     Debug.Log("Rolling the credits ~");
+                    movementController.DisableMovementOfPlayer();
                     ShowCredits(); // not sure if should change this to coroutine?
                 });
             });
@@ -52,8 +54,8 @@ public class FinaleController : MonoBehaviour
     // Call this method to start showing the Credits
     void ShowCredits()
     {
+        creditsCanvas.SetActive(true);
         blackscreenAnimator.SetBool("TurnBlack", true); // Fade credits black bg
-
         StartCoroutine(RollCredits());
     }
 

--- a/CULLinary/Assets/CULLinary/Code/LoadMainMenu.cs
+++ b/CULLinary/Assets/CULLinary/Code/LoadMainMenu.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// Add functions that need to be called when main menu is loaded here
+public class LoadMainMenu : MonoBehaviour
+{
+    public AudioMixer audioMixer;
+    public AudioClip victoryMusic;
+    public AudioSource backgroundMusic;
+
+    void Start()
+    {
+        OnMainMenuLoad();
+    }
+
+    private void OnMainMenuLoad()
+    {
+        // On main menu load, set Master_Vol to default
+        audioMixer.SetFloat("Master_Vol", 0f);
+        try
+        {
+            if (PlayerPrefs.GetInt("Just_Won_Game") == 1) {
+                backgroundMusic.clip = victoryMusic;
+                PlayerPrefs.SetInt("Just_Won_Game", 0);
+                backgroundMusic.Play();
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.Log("No player prefs registered in options");
+            Debug.Log(e);
+        }
+    }
+}

--- a/CULLinary/Assets/CULLinary/Code/LoadMainMenu.cs.meta
+++ b/CULLinary/Assets/CULLinary/Code/LoadMainMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d40599032a3a7254b9451f7c2885751b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary/Assets/CULLinary/Code/LoadingScreen.cs
+++ b/CULLinary/Assets/CULLinary/Code/LoadingScreen.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// Add functions that need to be called when a scene is loaded here
+public class LoadingScreen : MonoBehaviour
+{
+    public AudioMixer audioMixer;
+
+    void Start()
+    {
+        OnSceneLoad();
+    }
+
+    private void OnSceneLoad()
+    {
+        // On scene load, set Master_Vol to default
+        audioMixer.SetFloat("Master_Vol", 0f);
+    }
+}

--- a/CULLinary/Assets/CULLinary/Code/LoadingScreen.cs.meta
+++ b/CULLinary/Assets/CULLinary/Code/LoadingScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 102c5d29b14f89d47a303fe5af6ebf56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary/Assets/CULLinary/Code/Tutorial Codes/TutorialController_Return.cs
+++ b/CULLinary/Assets/CULLinary/Code/Tutorial Codes/TutorialController_Return.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Audio;
 using UnityEngine.SceneManagement;
 
 public class TutorialController_Return : MonoBehaviour
@@ -16,6 +17,8 @@ public class TutorialController_Return : MonoBehaviour
     public Restaurant_CustomerController customerController;
     // CookingStation to disable movement when speaking to ClownerCust
     public CookingStation movementController;
+
+    public AudioMixer audio; // to fade sounds
 
     bool cookedDish = false;
     bool pickedUpDish = false;
@@ -115,7 +118,9 @@ public class TutorialController_Return : MonoBehaviour
 
     IEnumerator LoadGameScene()
     {
-        yield return new WaitForSeconds(2.5f); // Have some time for player to process everything before loading the game scene
+        float duration = 2.5f;
+        StartCoroutine(AudioHelper.FadeAudio(audio, "Master_Vol", duration));
+        yield return new WaitForSeconds(duration); // Have some time for player to process everything before loading the game scene
 
         // OPTIONAL: Add shaking effect to camera??
 

--- a/CULLinary/Assets/CULLinary/Prefabs/Loading/LoadingScreen.prefab
+++ b/CULLinary/Assets/CULLinary/Prefabs/Loading/LoadingScreen.prefab
@@ -398,6 +398,7 @@ GameObject:
   - component: {fileID: 6776359961464420362}
   - component: {fileID: 6776359961464420363}
   - component: {fileID: 6776359961464420468}
+  - component: {fileID: 1352166791929008389}
   m_Layer: 5
   m_Name: LoadingScreen
   m_TagString: Untagged
@@ -491,6 +492,19 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &1352166791929008389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6776359961464420470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!1001 &1264196179682835967
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/CULLinary/Assets/CULLinary/Scenes/Main Menu.unity
+++ b/CULLinary/Assets/CULLinary/Scenes/Main Menu.unity
@@ -3701,6 +3701,7 @@ GameObject:
   - component: {fileID: 792474067}
   - component: {fileID: 792474066}
   - component: {fileID: 792474065}
+  - component: {fileID: 792474069}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -3792,6 +3793,21 @@ RectTransform:
   m_AnchoredPosition: {x: 1280, y: 720}
   m_SizeDelta: {x: 2560, y: 1440}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &792474069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792474064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d40599032a3a7254b9451f7c2885751b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+  victoryMusic: {fileID: 8300000, guid: a8d508b18d06e3f478bcd5a9fe9d6aa9, type: 3}
+  backgroundMusic: {fileID: 649744661}
 --- !u!1 &795655733
 GameObject:
   m_ObjectHideFlags: 0
@@ -7558,6 +7574,7 @@ MonoBehaviour:
   optionsMenu: {fileID: 248512419}
   mainButtonsMenu: {fileID: 1630335682}
   loadGameButton: {fileID: 1303500695}
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!1 &1858973430
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary/Assets/CULLinary/Scenes/Tut_boss.unity
+++ b/CULLinary/Assets/CULLinary/Scenes/Tut_boss.unity
@@ -678,6 +678,50 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 281c625a64e26d14ca757e47205e9f7c, type: 3}
+--- !u!1 &124169522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 124169524}
+  - component: {fileID: 124169523}
+  m_Layer: 0
+  m_Name: LoadStuff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &124169523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124169522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+--- !u!4 &124169524
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124169522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &179339969 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5941063237414671092, guid: 953fc872206a87f7ea24488d6f7f7f1c, type: 3}
@@ -2983,7 +3027,7 @@ AudioSource:
   m_GameObject: {fileID: 1684655777}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 4282217330375507991, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 8300000, guid: f66f6a632ce8b314cb8299bca864a269, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 0.5

--- a/CULLinary/Assets/CULLinary/Scenes/Tut_dungeon.unity
+++ b/CULLinary/Assets/CULLinary/Scenes/Tut_dungeon.unity
@@ -551,6 +551,50 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &379029563
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 379029565}
+  - component: {fileID: 379029564}
+  m_Layer: 0
+  m_Name: LoadStuff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &379029564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379029563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+--- !u!4 &379029565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379029563}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &404192243 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4535818720085487067, guid: 953fc872206a87f7ea24488d6f7f7f1c, type: 3}

--- a/CULLinary/Assets/CULLinary/Scenes/Tut_restaurant.unity
+++ b/CULLinary/Assets/CULLinary/Scenes/Tut_restaurant.unity
@@ -11018,7 +11018,7 @@ AudioSource:
   m_GameObject: {fileID: 629799468}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: -8296397853876076058, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
@@ -14199,6 +14199,50 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 2c413b0171854e740a46d6bfd4ecc7c6, type: 3}
   m_PrefabInstance: {fileID: 838728402}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &853597558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 853597560}
+  - component: {fileID: 853597559}
+  m_Layer: 0
+  m_Name: LoadStuff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &853597559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 853597558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+--- !u!4 &853597560
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 853597558}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &854916610
 GameObject:
   m_ObjectHideFlags: 0
@@ -18954,6 +18998,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1ca2ec35bf84c44857f0289ab482fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audio: {fileID: 0}
 --- !u!114 &1245957183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26695,7 +26740,7 @@ AudioSource:
   m_GameObject: {fileID: 1730376251}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 4282217330375507991, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 8300000, guid: 503aa10a433f8514e91c9adbd65bff76, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 0.75
@@ -28815,7 +28860,7 @@ AudioSource:
   m_GameObject: {fileID: 1911639341}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: -8296397853876076058, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 8300000, guid: abee18db2c86d4f438d9b728382f2a05, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 1

--- a/CULLinary/Assets/CULLinary/Scenes/Tut_returnRestaurant.unity
+++ b/CULLinary/Assets/CULLinary/Scenes/Tut_returnRestaurant.unity
@@ -10609,7 +10609,7 @@ AudioSource:
   m_GameObject: {fileID: 629799468}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: -8296397853876076058, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
@@ -11899,7 +11899,7 @@ AudioSource:
   m_GameObject: {fileID: 708127867}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: -8296397853876076058, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
   m_Volume: 1
@@ -14583,6 +14583,50 @@ Transform:
   - {fileID: 637736101}
   m_Father: {fileID: 451898730}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &904475014
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 904475016}
+  - component: {fileID: 904475015}
+  m_Layer: 0
+  m_Name: LoadStuff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &904475015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 904475014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+--- !u!4 &904475016
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 904475014}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &908228488
 PrefabInstance:
@@ -18856,6 +18900,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1ca2ec35bf84c44857f0289ab482fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audio: {fileID: 0}
 --- !u!114 &1245957183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -25401,6 +25446,7 @@ MonoBehaviour:
   dialogueLoader: {fileID: 182388394}
   customerController: {fileID: 1992024668}
   movementController: {fileID: 221291665}
+  audio: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!114 &1674238428
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26580,7 +26626,7 @@ AudioSource:
   m_GameObject: {fileID: 1730376251}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 4282217330375507991, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 8300000, guid: 503aa10a433f8514e91c9adbd65bff76, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 0.75
@@ -28722,7 +28768,7 @@ AudioSource:
   m_GameObject: {fileID: 1911639341}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: -8296397853876076058, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
   m_audioClip: {fileID: 8300000, guid: abee18db2c86d4f438d9b728382f2a05, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 1

--- a/CULLinary/Assets/Experiment/Finale_Restaurant.unity
+++ b/CULLinary/Assets/Experiment/Finale_Restaurant.unity
@@ -7817,7 +7817,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 200.00002}
+  m_AnchoredPosition: {x: 0, y: 200}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &202117473
@@ -21065,6 +21065,50 @@ Transform:
   - {fileID: 1125650503}
   m_Father: {fileID: 2050089463}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &605217635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 605217637}
+  - component: {fileID: 605217636}
+  m_Layer: 0
+  m_Name: LoadStuff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &605217636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 605217635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 102c5d29b14f89d47a303fe5af6ebf56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
+--- !u!4 &605217637
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 605217635}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &608181471
 GameObject:
@@ -41221,6 +41265,7 @@ MonoBehaviour:
   dialogueLoader: {fileID: 182388394}
   customerController: {fileID: 754227153}
   movementController: {fileID: 221291665}
+  audio: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!4 &1220177236
 Transform:
   m_ObjectHideFlags: 0
@@ -42393,6 +42438,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1ca2ec35bf84c44857f0289ab482fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audio: {fileID: 0}
 --- !u!114 &1245957183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -65655,7 +65701,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1217089844}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.5
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/CULLinary/Assets/Experiment/Finale_Restaurant.unity
+++ b/CULLinary/Assets/Experiment/Finale_Restaurant.unity
@@ -3091,9 +3091,9 @@ RectTransform:
   m_Father: {fileID: 1685499979}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &93818535
@@ -6860,9 +6860,9 @@ RectTransform:
   m_Father: {fileID: 403298297}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &181281805
@@ -7284,10 +7284,10 @@ RectTransform:
   m_Father: {fileID: 1905287256}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 902.9, y: -50}
+  m_SizeDelta: {x: 400, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &188806841
 MonoBehaviour:
@@ -7817,7 +7817,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 200}
+  m_AnchoredPosition: {x: 0, y: 200.00002}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &202117473
@@ -15006,9 +15006,9 @@ RectTransform:
   m_Father: {fileID: 1007059386}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &405076116
@@ -19575,9 +19575,9 @@ RectTransform:
   m_Father: {fileID: 1971386852}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &566364666
@@ -25029,9 +25029,9 @@ RectTransform:
   m_Father: {fileID: 188806840}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 200, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &725810915
@@ -25762,9 +25762,9 @@ RectTransform:
   m_Father: {fileID: 809327819}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 200, y: -109.8145}
   m_SizeDelta: {x: 539.347, y: 107.959}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &749291623
@@ -26590,9 +26590,9 @@ RectTransform:
   m_Father: {fileID: 1959151207}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &773108000
@@ -28311,10 +28311,10 @@ RectTransform:
   m_Father: {fileID: 1905287256}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 502.90002, y: -50}
+  m_SizeDelta: {x: 400, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &809327820
 MonoBehaviour:
@@ -29796,9 +29796,9 @@ RectTransform:
   m_Father: {fileID: 907198389}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &855319954
@@ -32210,9 +32210,9 @@ RectTransform:
   m_Father: {fileID: 1685499979}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &923596378
@@ -34534,10 +34534,10 @@ RectTransform:
   m_Father: {fileID: 1169591588}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 235.82002, y: -50}
+  m_SizeDelta: {x: 467.08, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1007059387
 MonoBehaviour:
@@ -40523,9 +40523,9 @@ RectTransform:
   m_Father: {fileID: 809327819}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 200, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1187645073
@@ -41261,6 +41261,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   blackscreenAnimator: {fileID: 2068215705}
   rollingCreditsAnimator: {fileID: 1649311388}
+  creditsCanvas: {fileID: 2068215701}
   clownerCust: {fileID: 1293389589}
   dialogueLoader: {fileID: 182388394}
   customerController: {fileID: 754227153}
@@ -42099,9 +42100,9 @@ RectTransform:
   m_Father: {fileID: 403298297}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1240465220
@@ -42439,6 +42440,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audio: {fileID: 0}
+  fadeDuration: 0.5
 --- !u!114 &1245957183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -56101,9 +56103,9 @@ RectTransform:
   m_Father: {fileID: 1959151207}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1626654450
@@ -57855,10 +57857,10 @@ RectTransform:
   m_Father: {fileID: 1169591588}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -50}
+  m_SizeDelta: {x: 467.08, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1685499980
 MonoBehaviour:
@@ -58611,9 +58613,9 @@ RectTransform:
   m_Father: {fileID: 907198389}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 702.9, y: -27.9175}
   m_SizeDelta: {x: 539.347, y: 55.835}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1707798155
@@ -63961,9 +63963,9 @@ RectTransform:
   m_Father: {fileID: 188806840}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 200, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1899082749
@@ -65150,9 +65152,9 @@ RectTransform:
   m_Father: {fileID: 1971386852}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1939368223
@@ -65701,7 +65703,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1217089844}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.5
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -66212,10 +66214,10 @@ RectTransform:
   m_Father: {fileID: 1169591588}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1169.98, y: -50}
+  m_SizeDelta: {x: 467.08, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1971386853
 MonoBehaviour:
@@ -69293,7 +69295,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2068215702
 RectTransform:
   m_ObjectHideFlags: 0
@@ -69556,9 +69558,9 @@ RectTransform:
   m_Father: {fileID: 1007059386}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 233.54, y: -91.438}
   m_SizeDelta: {x: 539.347, y: 71.206}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2069997337

--- a/CULLinary/Assets/Experiment/Prefabs/GameOverUI.prefab
+++ b/CULLinary/Assets/Experiment/Prefabs/GameOverUI.prefab
@@ -576,6 +576,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1ca2ec35bf84c44857f0289ab482fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audio: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!1 &4985153940049935185
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary/Assets/Experiment/Prefabs/Tut_GameOverUI.prefab
+++ b/CULLinary/Assets/Experiment/Prefabs/Tut_GameOverUI.prefab
@@ -363,6 +363,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f1ca2ec35bf84c44857f0289ab482fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audio: {fileID: 24100000, guid: 52b971ac47a1febcdb955854aff29ecb, type: 2}
 --- !u!1 &4985153940049935185
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary/Assets/Experiment/TestScripts/System/OptionsMenu.cs
+++ b/CULLinary/Assets/Experiment/TestScripts/System/OptionsMenu.cs
@@ -10,16 +10,32 @@ public class OptionsMenu : MonoBehaviour
     [SerializeField] private Slider sfxSlider;
     [SerializeField] private Slider bgSlider;
 
+    private static bool isFirstTime = true;
+
     private void Start()
     {
         try
         {
-            sfxSlider.value = PlayerPrefs.GetFloat("SFX_Vol");
-            bgSlider.value = PlayerPrefs.GetFloat("BG_Vol");
+            if (isFirstTime)
+            {
+                SetSFXVolume(0f);
+                SetBGVolume(0f);
+                sfxSlider.value = 0f;
+                bgSlider.value = 0f;
+            }
+            else
+            {
+                sfxSlider.value = PlayerPrefs.GetFloat("SFX_Vol");
+                bgSlider.value = PlayerPrefs.GetFloat("BG_Vol");
+            }
         }
         catch
         {
             Debug.Log("No player prefs registered in options");
+        }
+        finally
+        {
+            isFirstTime = false;
         }
     }
 

--- a/CULLinary/Assets/GameManager.cs
+++ b/CULLinary/Assets/GameManager.cs
@@ -1,13 +1,18 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Audio;
 using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
+    public AudioMixer audio;
+    public float fadeDuration = 0.5f;
+
     public void GameOver()
     {
         gameObject.SetActive(true);
+        StartCoroutine(AudioHelper.FadeAudio(audio, "Master_Vol", fadeDuration));
     }
 
     public void RestartButton()


### PR DESCRIPTION
* Fade audio at end of credits

* Fade audio after talking to Clowner NPC

* Fade audio on death or fake death

* Fade audio upon load or new game in main menu

* Fix issue where audio volume not located from options

* Fix audio mixer not used in some tutorial scenes

* Victory music plays on title screen after credits are seen

* Fix finale dialogue unclickable as blocked by credits

* Fix player able to move during credits

